### PR TITLE
Proposed fix for some of the CPANTESTER fail reports.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'perl', '5.14.0';
 requires 'Moose';
 requires 'JSON::MaybeXS';
 


### PR DESCRIPTION
Hi @pplu 

Please review the PR.

It provides fix for the some of the following FAIL reports as one of the test script "t/02_requiredness.t" using perl feature "package BLOCK" which was introduced in v5.14.

   https://www.cpantesters.org/cpan/report/69eef0be-edfc-11e8-98d5-bb14e5798fec
   https://www.cpantesters.org/cpan/report/48bd2f40-ee57-11e8-98d5-bb14e5798fec


      Execution of t/02_requiredness.t aborted due to compilation errors.
      t/02_requiredness.t ......... 
      Dubious, test returned 255 (wstat 65280, 0xff00)
      No subtests run 
      Invalid version format (non-numeric data) at t/03_location.t line 6, near "package TestModel "
      syntax error at t/03_location.t line 7, near "package TestModel {
      "
      Execution of t/03_location.t aborted due to compilation errors.

Many Thanks.
Best Regards,
Mohammad S Anwar
